### PR TITLE
Break out logs sync to own step

### DIFF
--- a/workflow.yaml
+++ b/workflow.yaml
@@ -208,7 +208,9 @@ jobs:
         run: |
           cd ${{ inputs.resources.top_work_dir }}/$(basename ${{ inputs.repositories.ml_arch_repo }})/scripts
           ./postprocess.sh ${{ inputs.resources.miniconda_loc }} ${{ inputs.resources.my_env }} ${{ inputs.resources.top_work_dir }}/$(basename ${{ inputs.repositories.ml_data_repo }})
-          echo "======> Stage PW logs to remote repo for committing"
+      - name: Sync logs
+        run: |
+          echo "======> Stage workflow logs to repo for committing"
           rsync -av ./logs ${{ inputs.resources.top_work_dir }}/$(basename ${{ inputs.repositories.ml_arch_repo }})/output_data/
       - name: Push branch to archive repository
         if: ${{ inputs.repositories.push_to_gh }}


### PR DESCRIPTION
Ensures full capture of preproc steps logs but
also takes care of issue of new step starting
right in the workflow run dir, which is where
the logs are located anyway.